### PR TITLE
企微push更新，控制台乱码修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+logs/
+*.log
+
+py311/
+__pycache__/
+
+.venv/
+
+*.pyd
+*.pyc
+

--- a/GUI.py
+++ b/GUI.py
@@ -466,6 +466,9 @@ class ConfigEditor:
             qiwei_url = ttk.Entry(qiwei_frame)
             qiwei_url.grid(row=0, column=1, sticky="ew")
             qiwei_frame.grid_columnconfigure(1, weight=1)
+            ttk.Label(qiwei_frame, text="Phone Number:").grid(row=1, column=0, sticky="w")
+            qiwei_phone = ttk.Entry(qiwei_frame)
+            qiwei_phone.grid(row=1, column=1, sticky="ew")
 
             # 类型切换处理
             def update_config_fields(*args):
@@ -530,6 +533,7 @@ class ConfigEditor:
                     service = {
                         "type": "qiwei",
                         "webhook_url": url,
+                        "phone": qiwei_phone.get(),
                         "title": f"企业微信 - {url[-20:]}"
                     }
                 
@@ -640,6 +644,10 @@ class ConfigEditor:
             qiwei_url = ttk.Entry(qiwei_frame)
             qiwei_url.insert(0, service.get("webhook_url", ""))
             qiwei_url.grid(row=0, column=1, sticky="ew")
+            ttk.Label(qiwei_frame, text="Phone Number:").grid(row=1, column=0, sticky="w")
+            qiwei_phone = ttk.Entry(qiwei_frame)
+            qiwei_phone.insert(0, service.get("phone", ""))
+            qiwei_phone.grid(row=1, column=1, sticky="ew")
 
             # 根据类型显示对应配置
             if service["type"] == "feishu":
@@ -653,7 +661,7 @@ class ConfigEditor:
             elif service["type"] == "qiwei":
                 feishu_frame.grid_remove()
                 server_frame.grid_remove()
-                qiwei_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
+                qiwei_frame.grid(row=2, column=0, columnspan=2, sticky="ew")
             else:
                 feishu_frame.grid_remove()
                 server_frame.grid_remove()
@@ -701,6 +709,7 @@ class ConfigEditor:
                     
                     service.update({
                         "webhook_url": url,
+                        "phone": qiwei_phone.get(),
                         "title": f"企微推送 - {url[-20:]}"
                     })
                 else:
@@ -975,6 +984,9 @@ class ConfigEditor:
             ttk.Label(qiwei_frame, text="Webhook URL:").grid(row=0, column=0, sticky="w")
             qiwei_url = ttk.Entry(qiwei_frame)
             qiwei_url.grid(row=0, column=1, sticky="ew")
+            ttk.Label(qiwei_frame, text="Phone Number:").grid(row=1, column=0, sticky="w")
+            qiwei_phone = ttk.Entry(qiwei_frame)
+            qiwei_phone.grid(row=1, column=1, sticky="ew")
             qiwei_frame.grid_columnconfigure(1, weight=1)
 
             # 类型切换处理
@@ -1039,6 +1051,7 @@ class ConfigEditor:
                     service = {
                         "type": "qiwei",
                         "webhook_url": url,
+                        "phone": qiwei_phone.get(),
                         "title": f"企业微信 - {url[-20:]}"
                     }
                 else:
@@ -1133,7 +1146,12 @@ class ConfigEditor:
             ttk.Label(qiwei_frame, text="Webhook URL:").grid(row=0, column=0, sticky="w")
             qiwei_url = ttk.Entry(qiwei_frame)
             qiwei_url.insert(0, service.get("webhook_url", ""))
-            qiwei_url.grid(row=0, column=1, sticky="ew")
+            qiwei_url.grid(row=0, column=1, sticky="ew")  # ← 需要加这一行
+
+            ttk.Label(qiwei_frame, text="Phone Number:").grid(row=2, column=0, sticky="w")
+            qiwei_phone = ttk.Entry(qiwei_frame)
+            qiwei_phone.insert(0, service.get("phone", ""))
+            qiwei_phone.grid(row=2, column=1, sticky="ew")
 
             # 根据类型显示对应配置
             if service["type"] == "feishu":
@@ -1147,7 +1165,7 @@ class ConfigEditor:
             elif service["type"] == "qiwei":
                 feishu_frame.grid_remove()
                 server_frame.grid_remove()
-                qiwei_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
+                qiwei_frame.grid(row=2, column=0, columnspan=2, sticky="ew")
             else:
                 feishu_frame.grid_remove()
                 server_frame.grid_remove()
@@ -1194,6 +1212,7 @@ class ConfigEditor:
                     
                     service.update({
                         "webhook_url": url,
+                        "phone": qiwei_phone.get(),
                         "title": f"企微推送 - {url[-20:]}"
                     })
                 else: 

--- a/config.json
+++ b/config.json
@@ -8,10 +8,10 @@
       "username": "username",
       "cookies_file": "cookies/username.json",
       "user_agent": "",
+      "ibex": "",
       "tasks": {
         "签到任务": true,
         "激励碎片任务": true,
-        "额外激励任务": true,
         "章节卡任务": true,
         "每日抽奖任务": true
       },
@@ -24,6 +24,11 @@
         {
           "type": "serverchan",
           "sckey": "SCUxxxxxx"
+        },
+        {
+          "type": "qiwei",
+          "webhook_url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxxxxxxx",
+          "phone": "xxxxxxxxxxx8645"
         }
       ]
     }

--- a/logger.py
+++ b/logger.py
@@ -5,6 +5,12 @@ import logging.handlers
 LOG_DIR = 'logs'
 DEFAULT_LOG_RETENTION = 7
 
+# 确保控制台输出使用UTF-8编码
+if sys.stdout.encoding != 'utf-8':
+    # Windows环境下设置控制台编码
+    if sys.platform == 'win32':
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
 class LoggerManager:
     _instance = None
     _logger = None

--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,5 @@
 import logging
-import os
+import os, sys
 import logging.handlers
 
 LOG_DIR = 'logs'
@@ -9,6 +9,7 @@ DEFAULT_LOG_RETENTION = 7
 if sys.stdout.encoding != 'utf-8':
     # Windows环境下设置控制台编码
     if sys.platform == 'win32':
+        import io
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
 class LoggerManager:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+import os
+os.environ["PYTHONIOENCODING"] = "utf-8"
+
 from QDjob import MainApp
 
 

--- a/push.py
+++ b/push.py
@@ -158,8 +158,9 @@ class ServerChan(PushService):
 class QiweiPush(PushService):
     """Qiwei推送"""
 
-    def __init__(self, webhook_url: str):
+    def __init__(self, webhook_url: str, phone: str = ""):
         self.webhook_url = webhook_url
+        self.phone = phone
         super().__init__()
 
     def _validate_config(self):
@@ -172,9 +173,10 @@ class QiweiPush(PushService):
         try:
             url = self.webhook_url
             data = {
-                "msgtype": "markdown",
-                "markdown": {
-                    "content": f'## {title} \n {content}',
+                "msgtype": "text",
+                "text": {
+                    "content": f'QDjob-{title} \n {content}',
+                    "mentioned_mobile_list":[self.phone] if self.phone else []
                 },
             }
 


### PR DESCRIPTION
## feat:企微通知支持艾特自己fix:修复Windows Server控制台可能出现中文乱码问题

企微可以输出自己手机号（要求企微绑定的手机号），后续通知时会自动艾特，对应示例配置文件已同步更改

Windows Server早先版本输出中文会乱码，在logger.py开头补充编码处理

本地测试通过